### PR TITLE
Add UniRef

### DIFF
--- a/wipe/modules/functiondb.py
+++ b/wipe/modules/functiondb.py
@@ -1,0 +1,82 @@
+import os
+import subprocess
+from pathlib import Path
+from wipe.modules.utils import write_json_log, run_command
+
+def run_functional_annotation(indir, diamonddb, outdir, threads):
+    """
+    Run functional annotation using DIAMOND against UniRef database.
+    
+    Args:
+        indir (str): Input directory containing protein files (all.faa)
+        diamonddb (str): Path to DIAMOND database
+        outdir (str): Output directory for results
+        threads (int): Number of threads to use
+    """
+    # Create output directory
+    os.makedirs(outdir, exist_ok=True)
+    
+    # Input validation
+    protein_file = os.path.join(indir, "all.faa")
+    if not os.path.exists(protein_file):
+        raise FileNotFoundError(f"Protein file not found: {protein_file}")
+    
+    if not os.path.exists(diamonddb):
+        raise FileNotFoundError(f"DIAMOND database not found: {diamonddb}")
+
+    # Output files
+    diamond_out = os.path.join(outdir, "diamond_results.m8")
+    uniref_map = os.path.join(outdir, "uniref.map")
+    
+    try:
+        # Run DIAMOND blastp
+        diamond_cmd = [
+            "diamond", "blastp",
+            "--threads", str(threads),
+            "--db", diamonddb,
+            "--query", protein_file,
+            "--out", diamond_out,
+            "--id", "90",
+            "--subject-cover", "80",
+            "--query-cover", "80",
+            "--index-chunks", "1",
+            "--max-target-seqs", "1"
+        ]
+        
+        run_command(diamond_cmd)
+        
+        # Process DIAMOND results to create uniref.map
+        # This assumes the diamond output is in standard blast tabular format
+        with open(diamond_out) as f_in, open(uniref_map, 'w') as f_out:
+            for line in f_in:
+                query, target = line.split('\t')[:2]
+                f_out.write(f"{query}\t{target}\n")
+        
+        # Compress uniref.map to uniref.map.xz
+        run_command(["xz", "-z", uniref_map])
+        
+        # Log success
+        write_json_log(
+            {
+                "status": "success",
+                "process": "functiondb",
+                "input_file": protein_file,
+                "output_files": {
+                    "diamond_results": diamond_out,
+                    "uniref_map": uniref_map + ".xz"
+                }
+            },
+            outdir
+        )
+        
+    except Exception as e:
+        # Log error
+        write_json_log(
+            {
+                "status": "error",
+                "process": "functiondb",
+                "error": str(e)
+            },
+            outdir
+        )
+        raise 

--- a/wipe/modules/uniref.py
+++ b/wipe/modules/uniref.py
@@ -1,0 +1,133 @@
+import re
+import os
+import lzma
+from pathlib import Path
+
+def process_uniref_xml(xml_file, output_tsv):
+    """
+    Process UniRef XML file and extract relevant information.
+    
+    Args:
+        xml_file (str): Path to input XML file (can be gzipped)
+        output_tsv (str): Path to output TSV file
+    """
+    # Regex patterns
+    pentr = re.compile(r'^<entry id="UniRef\d+_(.+)" updated=".+">$')
+    pname = re.compile(r'^<n>Cluster: (.+)<n>$')
+    pprop = re.compile(r'^<property type="(.+)" value="(.+)"/>$')
+    
+    with open(output_tsv, 'w') as out_f:
+        with open(xml_file, 'r') as f:
+            for line in f:
+                # Only read main entries, not members
+                if not line.startswith('<entry id='):
+                    continue
+                line = line.rstrip('\r\n')
+                
+                # UniRef identifier
+                m = pentr.search(line)
+                if not m:
+                    raise ValueError(f'Invalid entry line: {line}')
+                head = [m.group(1)]
+                
+                # Cluster name
+                line = next(f).rstrip('\r\n')
+                m = pname.search(line)
+                if not m:
+                    raise ValueError(f'Missing cluster name for {head[0]}')
+                head.append(m.group(1))
+                
+                # Common properties
+                for prop in ('member count', 'common taxon', 'common taxon ID'):
+                    line = next(f).rstrip('\r\n')
+                    m = pprop.search(line)
+                    if not m or m.group(1) != prop:
+                        raise ValueError(f'Missing {prop} for {head[0]}')
+                    head.append(m.group(2))
+                    if prop == 'common taxon' and m.group(2) == 'unknown':
+                        head.append('0')
+                        break
+                
+                # Write header: UniProt, name, members, organism, taxId
+                out_f.write('\t'.join(head) + '\n')
+
+def merge_uniref_maps(uniref90_map, uniref50_map, output_file, simplify=False):
+    """
+    Merge UniRef90 (preferred) and UniRef50 maps.
+    
+    Args:
+        uniref90_map (str): Path to UniRef90 mapping file
+        uniref50_map (str): Path to UniRef50 mapping file
+        output_file (str): Path to output merged map file
+        simplify (bool): If True, simplify UniRef IDs by taking only part after '_'
+    """
+    res = {}
+    res_add = res.setdefault
+    
+    # Ensure the parent directory of output_file exists
+    Path(output_file).parent.mkdir(parents=True, exist_ok=True)
+    
+    # Define how to process each entry based on the simplify flag
+    if simplify:
+        process_entry = lambda entry: entry.split('_')[1]  # Simplified: Take only the part after '_'
+    else:
+        process_entry = lambda entry: entry  # No simplification
+    
+    # Read UniRef90 file
+    with open(uniref90_map, 'r') as f:
+        for line in f:
+            orf, entry = line.rstrip().split('\t')[:2]
+            g, i = orf.split('_')
+            res_add(g, {})[int(i)] = process_entry(entry)
+    
+    # Read UniRef50 file
+    with open(uniref50_map, 'r') as f:
+        for line in f:
+            orf, entry = line.rstrip().split('\t')[:2]
+            g, i = orf.split('_')
+            if g not in res or int(i) not in res[g]:
+                res_add(g, {})[int(i)] = process_entry(entry)
+    
+    # Write output to the specified output_file
+    with open(output_file, 'w') as out_f:
+        for g, entries in sorted(res.items()):
+            for i, entry in sorted(entries.items()):
+                out_f.write(f'{g}_{i}\t{entry}\n')
+
+def extract_uniref_names(uniref_map, uniref90_names, uniref50_names, output_names):
+    """
+    Extract UniRef names for the IDs in the mapping file.
+    
+    Args:
+        uniref_map (str): Path to UniRef mapping file
+        uniref90_names (str): Path to UniRef90 names TSV file
+        uniref50_names (str): Path to UniRef50 names TSV file
+        output_names (str): Path to output names file
+    """
+    # Read UniRef IDs from map file
+    urs = set()
+    with open(uniref_map, "r") as f:
+        for line in f:
+            uid = line.strip().split('\t')[1]
+            urs.add(uid)
+    
+    # Write names to output file
+    with open(output_names, 'w') as fo:
+        # First try UniRef90
+        seen = []
+        with open(uniref90_names, 'r') as fi:
+            for line in fi:
+                if not (line.startswith('#') or line.startswith("Error: ")):
+                    ur, name, _ = line.split('\t', 2)
+                    if ur in urs:
+                        print(ur, name, sep='\t', file=fo)
+                        seen.append(ur)
+        
+        # Then try UniRef50 for remaining IDs
+        seen = set(seen)
+        with open(uniref50_names, 'r') as fi:
+            for line in fi:
+                if not (line.startswith('#') or line.startswith("Error: ")):
+                    ur, name, _ = line.split('\t', 2)
+                    if ur in urs and ur not in seen:
+                        print(ur, name, sep='\t', file=fo) 

--- a/wipe/wipe.py
+++ b/wipe/wipe.py
@@ -334,5 +334,41 @@ def extract_names(map_file, uniref90_names, uniref50_names, output_names):
         raise
 
 
+@uniref.command()
+@click.option("--level", type=click.Choice(['50', '90']), required=True,
+              help="UniRef database level to download (50 or 90)")
+@click.option("-o", "--outdir", required=True,
+              help="Output directory for downloaded files")
+def download(level, outdir):
+    """
+    Download UniRef database files from UniProt FTP server.
+    
+    Downloads all files for either UniRef50 or UniRef90 from the UniProt FTP server.
+    Uses wget to mirror the relevant directory while preserving the file structure.
+    """
+    try:
+        os.makedirs(outdir, exist_ok=True)
+        
+        base_url = f"ftp://ftp.uniprot.org/pub/databases/uniprot/current_release/uniref/uniref{level}/"
+        wget_cmd = [
+            "wget",
+            "-r",  # recursive download
+            "-np",  # no parent directories
+            "-nH",  # no host directories
+            "--cut-dirs=6",  # remove 6 levels of directories
+            "-R", "index.html*",  # exclude index.html files
+            "-P", outdir,  # output directory
+            base_url
+        ]
+        
+        click.echo(f"Downloading UniRef{level} database files...")
+        run_command(wget_cmd)
+        click.echo(f"UniRef{level} download complete")
+        
+    except Exception as e:
+        click.echo(f"Error downloading UniRef{level}: {str(e)}", err=True)
+        raise
+
+
 if __name__ == "__main__":
     wipe()

--- a/wipe/wipe.py
+++ b/wipe/wipe.py
@@ -11,7 +11,9 @@ from wipe.modules.gsearch import create_db, update_db
 from wipe.modules.annotate import annotate_multiple
 from wipe.modules.barrnap import run_barrnap_single
 from wipe.modules.recover_16s import extract_16s_from_tlp
-from wipe.modules.utils import load_metadata
+from wipe.modules.utils import load_metadata, run_command
+from wipe.modules.functiondb import run_functional_annotation
+from wipe.modules.uniref import process_uniref_xml, merge_uniref_maps, extract_uniref_names
 
 
 # takes in a directory of genomes
@@ -187,6 +189,33 @@ def create(indir, outdir, nthreads):
 
 
 # fmt: off
+@wipe.command()
+@click.option("-i", "--indir", required=True, type=click.Path(exists=True),
+              help="Input directory containing protein files")
+@click.option("-db", "--diamonddb", required=True, type=click.Path(exists=True),
+              help="Path to DIAMOND database")
+@click.option("-o", "--outdir", required=True,
+              help="Output directory for functional annotation results")
+@click.option("-t", "--threads", default=4,
+              help="Number of threads to use (default: 4)")
+# fmt: on
+def functiondb(indir, diamonddb, outdir, threads):
+    """
+    Run functional annotation pipeline using DIAMOND and UniRef database.
+    
+    This command expects:
+    1. Input directory with protein files (all.faa)
+    2. Pre-built DIAMOND database
+    3. Output directory for results
+    
+    Produces:
+    - uniref.map.xz: Mapping between query proteins and UniRef hits
+    - diamond_results.m8: Raw DIAMOND output
+    """
+    run_functional_annotation(indir, diamonddb, outdir, threads)
+
+
+# fmt: off
 @gsearch.command()
 @click.option("-i", "--indir", required=True, type=click.Path(exists=True),
               help="Input directory containing new fasta or fna.gz files.")
@@ -199,6 +228,110 @@ def create(indir, outdir, nthreads):
 # fmt: on
 def update(indir, db, outdir, nthreads, backup_dir):
     update_db(db, indir, nthreads=nthreads, backup_dir=backup_dir)
+
+
+@wipe.command()
+@click.option("-i", "--input-fasta", required=True, type=click.Path(exists=True),
+              help="Input FASTA file (UniRef50 or UniRef90)")
+@click.option("-o", "--output-db", required=True,
+              help="Output DIAMOND database path")
+@click.option("-t", "--threads", default=4,
+              help="Number of threads to use (default: 4)")
+def makedb(input_fasta, output_db, threads):
+    """
+    Create a DIAMOND database from a UniRef FASTA file.
+    
+    This command creates a DIAMOND database that can be used for protein alignment.
+    It expects a UniRef FASTA file (either UniRef50 or UniRef90) as input.
+    """
+    try:
+        # Create output directory if it doesn't exist
+        os.makedirs(os.path.dirname(output_db), exist_ok=True)
+        
+        # Build DIAMOND database
+        diamond_cmd = [
+            "diamond", "makedb",
+            "--threads", str(threads),
+            "--in", input_fasta,
+            "--db", output_db
+        ]
+        
+        run_command(diamond_cmd)
+        
+    except Exception as e:
+        click.echo(f"Error creating DIAMOND database: {str(e)}", err=True)
+        raise
+
+
+@wipe.group()
+def uniref():
+    """Commands for working with UniRef databases and annotations."""
+    pass
+
+
+@uniref.command()
+@click.option("-i", "--xml-file", required=True, type=click.Path(exists=True),
+              help="Input UniRef XML file (can be gzipped)")
+@click.option("-o", "--output-tsv", required=True,
+              help="Output TSV file path")
+def process_xml(xml_file, output_tsv):
+    """
+    Process UniRef XML file to extract relevant information.
+    
+    This command processes a UniRef XML file (either UniRef50 or UniRef90)
+    and extracts relevant information into a TSV file.
+    """
+    try:
+        process_uniref_xml(xml_file, output_tsv)
+    except Exception as e:
+        click.echo(f"Error processing UniRef XML: {str(e)}", err=True)
+        raise
+
+
+@uniref.command()
+@click.option("--uniref90-map", required=True, type=click.Path(exists=True),
+              help="Path to UniRef90 mapping file")
+@click.option("--uniref50-map", required=True, type=click.Path(exists=True),
+              help="Path to UniRef50 mapping file")
+@click.option("-o", "--output-file", required=True,
+              help="Output merged map file path")
+@click.option("--simplify", is_flag=True, default=False,
+              help="Simplify UniRef IDs by taking only part after '_'")
+def merge_maps(uniref90_map, uniref50_map, output_file, simplify):
+    """
+    Merge UniRef90 and UniRef50 mapping files.
+    
+    This command merges UniRef90 (preferred) and UniRef50 maps into a single file.
+    UniRef90 mappings take precedence over UniRef50 mappings.
+    """
+    try:
+        merge_uniref_maps(uniref90_map, uniref50_map, output_file, simplify)
+    except Exception as e:
+        click.echo(f"Error merging UniRef maps: {str(e)}", err=True)
+        raise
+
+
+@uniref.command()
+@click.option("--map-file", required=True, type=click.Path(exists=True),
+              help="Path to UniRef mapping file")
+@click.option("--uniref90-names", required=True, type=click.Path(exists=True),
+              help="Path to UniRef90 names TSV file")
+@click.option("--uniref50-names", required=True, type=click.Path(exists=True),
+              help="Path to UniRef50 names TSV file")
+@click.option("-o", "--output-names", required=True,
+              help="Output names file path")
+def extract_names(map_file, uniref90_names, uniref50_names, output_names):
+    """
+    Extract UniRef names for the IDs in the mapping file.
+    
+    This command takes a UniRef mapping file and extracts the corresponding
+    names from UniRef90 and UniRef50 name files.
+    """
+    try:
+        extract_uniref_names(map_file, uniref90_names, uniref50_names, output_names)
+    except Exception as e:
+        click.echo(f"Error extracting UniRef names: {str(e)}", err=True)
+        raise
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds `wipe` commands and subcommands for UniRef functionality, see demo usage below:
```bash
working_dir=/ddn_scratch/lpatel/projects/2025-01-08_wipe/test_run
prodigal_dir=/ddn_scratch/y1weng/31_hcom2/output/proteins

# downloads uniref databases
wipe uniref download --level 50 --outdir $working_dir/uniref50_db
wipe uniref download --level 90 --outdir $working_dir/uniref90_db

# creates diamond databases
wipe makedb -i $working_dir/uniref50_db/uniref50.fasta.gz -o $working_dir/uniref50_db/uniref50.dmnd -t 8
wipe makedb -i $working_dir/uniref90_db/uniref90.fasta.gz -o $working_dir/uniref90_db/uniref90.dmnd -t 8

# runs diamond blastp to create uniref map
wipe functiondb \
  -i $prodigal_dir \
  -db $working_dir/uniref50_db/uniref50.dmnd \
  -o $working_dir/uniref50_db \
  -t 2

wipe functiondb \
  -i $prodigal_dir \
  -db $working_dir/uniref90_db/uniref90.dmnd \
  -o $working_dir/uniref90_db \
  -t 2

# combines diamond results into a single map file
wipe uniref merge-maps \
  --uniref90-map $working_dir/uniref90_db/diamond_results.m8 \
  --uniref50-map $working_dir/uniref50_db/diamond_results.m8 \
  -o $working_dir/uniref.map \
   --simplify

# converts xml to tsv
wipe uniref process-xml -i $working_dir/uniref50_db/uniref50.xml.gz -o $working_dir/uniref50_db/uniref50.tsv
wipe uniref process-xml -i $working_dir/uniref90_db/uniref90.xml.gz -o $working_dir/uniref90_db/uniref90.tsv

# extracts names from map and uniref tsv files
wipe uniref extract-names \
  --map-file $working_dir/uniref.map \
  --uniref90-names $working_dir/uniref90_db/uniref90.tsv \
  --uniref50-names $working_dir/uniref50_db/uniref50.tsv \
  -o $working_dir/uniref.names
  ```